### PR TITLE
Ensure the subscription_id is an int

### DIFF
--- a/api/yelp_beans/routes/api/v1/preferences.py
+++ b/api/yelp_beans/routes/api/v1/preferences.py
@@ -28,7 +28,7 @@ def preferences_api():
     return resp
 
 
-@preferences_blueprint.route('/subscription/<subscription>', methods=["POST"])
+@preferences_blueprint.route('/subscription/<subscription_id>', methods=["POST"])
 def preferences_api_post(subscription_id):
     data = request.json
     user = get_user(data.get('email'))

--- a/api/yelp_beans/routes/api/v1/preferences.py
+++ b/api/yelp_beans/routes/api/v1/preferences.py
@@ -28,8 +28,8 @@ def preferences_api():
     return resp
 
 
-@preferences_blueprint.route('/subscription/<subscription_id>', methods=["POST"])
-def preferences_api_post(subscription_id):
+@preferences_blueprint.route('/subscription/<int:subscription_id>', methods=["POST"])
+def preferences_api_post(subscription_id: int) -> str:
     data = request.json
     user = get_user(data.get('email'))
     del data['email']


### PR DESCRIPTION
By default this is parsed as a string, but the id is stored as a int in
the database. This meant when we later compared the MeetingSubscription
model's id to route variable subscription_id it never matched since it
was comparing an int and a string. We could convert this to an int at
that point, but I think it it is better to have it be part of how the
route is defined. The biggest downside is that it returns a 404 if you
construct a url that has a non-int subscription_id (api/v1/subscription/a)